### PR TITLE
Use the same (new) prometheus libraries for everything.

### DIFF
--- a/go/lib/ringbuf/metrics.go
+++ b/go/lib/ringbuf/metrics.go
@@ -77,8 +77,8 @@ func newMetrics(desc string, labels prometheus.Labels) *metrics {
 		readCalls:     ReadCalls.With(l),
 		writesBlocked: WritesBlocked.With(l),
 		readsBlocked:  ReadsBlocked.With(l),
-		writeEntries:  WriteEntries.With(l),
-		readEntries:   ReadEntries.With(l),
+		writeEntries:  WriteEntries.With(l).(prometheus.Histogram),
+		readEntries:   ReadEntries.With(l).(prometheus.Histogram),
 		maxEntries:    MaxEntries.With(l),
 		usedEntries:   UsedEntries.With(l),
 	}

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -316,51 +316,88 @@
 			"revisionTime": "2017-07-14T08:24:55Z"
 		},
 		{
-			"checksumSHA1": "pjycJuWYfhbN2FgitW73b1bwteI=",
+			"checksumSHA1": "zZFKpzqik3KcOHkCDwvpBQVKZ+U=",
+			"path": "github.com/prometheus/client_golang/api",
+			"revision": "7490f0a74525a1f863eaf81b42f3ead3a1ecc43a",
+			"revisionTime": "2019-03-25T08:23:28Z"
+		},
+		{
+			"checksumSHA1": "mpX6UVfirSIybAAZ3cRmVo/DyWg=",
 			"path": "github.com/prometheus/client_golang/api/prometheus/v1",
-			"revision": "18d13eacc9cce330610a70daf4ed0fef2e846589",
-			"revisionTime": "2019-01-15T21:34:51Z"
+			"revision": "7490f0a74525a1f863eaf81b42f3ead3a1ecc43a",
+			"revisionTime": "2019-03-25T08:23:28Z"
 		},
 		{
-			"checksumSHA1": "Ph+qmEo8RdBKBHZUhx0y5Oyk/U0=",
-			"license": "APL 2.0",
+			"checksumSHA1": "gQVcoum3Wk1rKcUtaLOoZojxeLI=",
 			"path": "github.com/prometheus/client_golang/prometheus",
-			"revision": "334af0119a8f8fb6af5bb950d535c482cac7f836",
-			"revisionTime": "2016-10-17T12:35:36Z"
+			"revision": "7490f0a74525a1f863eaf81b42f3ead3a1ecc43a",
+			"revisionTime": "2019-03-25T08:23:28Z"
 		},
 		{
-			"checksumSHA1": "lG3//eDlwqA4IOuAPrNtLh9G0TA=",
-			"license": "APL 2.0",
+			"checksumSHA1": "UBqhkyjCz47+S19MVTigxJ2VjVQ=",
+			"path": "github.com/prometheus/client_golang/prometheus/internal",
+			"revision": "7490f0a74525a1f863eaf81b42f3ead3a1ecc43a",
+			"revisionTime": "2019-03-25T08:23:28Z"
+		},
+		{
+			"checksumSHA1": "wR/mIioOTUWo2HmQaACuux6MJ5A=",
 			"path": "github.com/prometheus/client_golang/prometheus/promhttp",
-			"revision": "334af0119a8f8fb6af5bb950d535c482cac7f836",
-			"revisionTime": "2016-10-17T12:35:36Z"
+			"revision": "7490f0a74525a1f863eaf81b42f3ead3a1ecc43a",
+			"revisionTime": "2019-03-25T08:23:28Z"
 		},
 		{
-			"checksumSHA1": "mHyjbJ3BWOfUV6q9f5PBt0gaY1k=",
-			"license": "APL 2.0",
+			"checksumSHA1": "DvwvOlPNAgRntBzt3b3OSRMS2N4=",
+			"path": "github.com/prometheus/client_model/go",
+			"revision": "fa8ad6fec33561be4280a8f0514318c79d7f6cb6",
+			"revisionTime": "2015-02-12T10:17:44Z"
+		},
+		{
+			"checksumSHA1": "ljxJzXiQ7dNsmuRIUhqqP+qjRWc=",
 			"path": "github.com/prometheus/common/expfmt",
-			"revision": "85637ea67b04b5c3bb25e671dacded2977f8f9f6",
-			"revisionTime": "2016-10-02T21:02:34Z"
+			"revision": "1ab4d74fc89940cfbc3c2b3a89821336cdefa119",
+			"revisionTime": "2019-03-21T12:45:55Z"
 		},
 		{
-			"checksumSHA1": "GWlM3d2vPYyNATtTFgftS10/A9w=",
-			"license": "3-BSD",
+			"checksumSHA1": "1Mhfofk+wGZ94M0+Bd98K8imPD4=",
 			"path": "github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg",
-			"revision": "85637ea67b04b5c3bb25e671dacded2977f8f9f6",
-			"revisionTime": "2016-10-02T21:02:34Z"
+			"revision": "1ab4d74fc89940cfbc3c2b3a89821336cdefa119",
+			"revisionTime": "2019-03-21T12:45:55Z"
 		},
 		{
 			"checksumSHA1": "oKlDMiV9MHiguN2YtUnZP9s+2aw=",
 			"path": "github.com/prometheus/common/model",
-			"revision": "2998b132700a7d019ff618c06a234b47c1f3f681",
-			"revisionTime": "2019-01-07T10:31:13Z"
+			"revision": "1ab4d74fc89940cfbc3c2b3a89821336cdefa119",
+			"revisionTime": "2019-03-21T12:45:55Z"
 		},
 		{
-			"checksumSHA1": "W218eJZPXJG783fUr/z6IaAZyes=",
-			"license": "APL 2.0",
+			"checksumSHA1": "wNC6xyd8Rc5unbdKT1N+d2PQ3Ww=",
 			"path": "github.com/prometheus/procfs",
-			"revision": "abf152e5f3e97f2fafac028d2cc06c1feb87ffa5",
-			"revisionTime": "2016-04-11T19:08:41Z"
+			"revision": "55ae3d9d557340b5bc24cd8aa5f6fa2c2ab31352",
+			"revisionTime": "2019-03-22T15:14:04Z"
+		},
+		{
+			"checksumSHA1": "LYVpuGbR9IwmgIg7coejzySrOTI=",
+			"path": "github.com/prometheus/procfs/internal/util",
+			"revision": "55ae3d9d557340b5bc24cd8aa5f6fa2c2ab31352",
+			"revisionTime": "2019-03-22T15:14:04Z"
+		},
+		{
+			"checksumSHA1": "sQdIWe2uRUIt0s9qRPeLg/Ekxhw=",
+			"path": "github.com/prometheus/procfs/iostats",
+			"revision": "55ae3d9d557340b5bc24cd8aa5f6fa2c2ab31352",
+			"revisionTime": "2019-03-22T15:14:04Z"
+		},
+		{
+			"checksumSHA1": "HSP5hVT0CNMRa8+Xtz4z2Ic5U0E=",
+			"path": "github.com/prometheus/procfs/nfs",
+			"revision": "55ae3d9d557340b5bc24cd8aa5f6fa2c2ab31352",
+			"revisionTime": "2019-03-22T15:14:04Z"
+		},
+		{
+			"checksumSHA1": "VuVXG7AgTutgXqgp1CqyW5SuSZ8=",
+			"path": "github.com/prometheus/procfs/xfs",
+			"revision": "55ae3d9d557340b5bc24cd8aa5f6fa2c2ab31352",
+			"revisionTime": "2019-03-22T15:14:04Z"
 		},
 		{
 			"checksumSHA1": "egQy+ytQKjfBN1oRKQJ/pxIvjYc=",


### PR DESCRIPTION
prometheus/client_model differs in the two versions used up to now.
Chosen the new API version and adapted the existing code that was
not building (only two lines, minor change).
Tested build in an empty ubuntu container.